### PR TITLE
Delete patch api calls and tests

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -65,4 +65,22 @@ export const addPalette = async (project_id, palette_body) => {
   }
   const id = await response.json();
   return id
+};
+
+export const removeItem = async (id, item) => {
+  const url = item === 'project' ?
+    `https://palette-picks.herokuapp.com/api/v1/projects/${id}` :
+    `https://palette-picks.herokuapp.com/api/v1/palettes/${id}`;
+  const options = {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    };
+  const response = await fetch(url, options);
+  if(!response.ok) {
+    throw new Error(`Error: There was a problem deleting ${item} id ${id}.`);
+  }
+  const responseMessage = await response.json();
+  return responseMessage;
 }

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -83,4 +83,25 @@ export const removeItem = async (id, item) => {
   }
   const responseMessage = await response.json();
   return responseMessage;
-}
+};
+
+export const updateItem = async (id, item, updated_name) => {
+  const url = item === 'project' ?
+    `https://palette-picks.herokuapp.com/api/v1/projects/${id}` :
+    `https://palette-picks.herokuapp.com/api/v1/palettes/${id}`;
+  const options = {
+    method: 'PATCH',
+    body: JSON.stringify({name: updated_name}),
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  };
+  const response = await fetch(url, options);
+  if(!response.ok) {
+    throw new Error(`Error: There was a problem updating ${item} id ${id}.`);
+  }
+  const responseId = await response.json();
+  return responseId;
+};
+
+// { id: id[0] }

--- a/src/apiCalls.test.js
+++ b/src/apiCalls.test.js
@@ -1,4 +1,4 @@
-import { getProjects, addProject, getPalettes, getSpecificPalette, addPalette }
+import { getProjects, addProject, getPalettes, getSpecificPalette, addPalette, removeItem }
   from './apiCalls';
 
 describe('getProjects', () => {
@@ -288,4 +288,94 @@ describe('addPalette', () => {
     expect(addPalette(mockProjectId, mockBody)).rejects.toEqual(
       Error('Error: There was a problem adding your palette.'));
   });
+});
+
+describe('removeItem', () => {
+
+  describe('remove Project', () => {
+    let mockId = 123;
+    let mockResponse = `Project with id 123 has been removed successfully`;
+    const mockOptions = {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      };
+
+    beforeEach(() => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          json: () => {
+            return Promise.resolve(mockResponse);
+          }
+        });
+      });
+    });
+
+    it('should be passed the correct URL', () => {
+      removeItem(mockId, 'project');
+      expect(window.fetch).toHaveBeenCalledWith(
+        'https://palette-picks.herokuapp.com/api/v1/projects/123',
+          mockOptions);
+    });
+
+    it('should return an object with the project id', () => {
+      expect(removeItem(mockId, 'project')).resolves.toEqual(mockResponse);
+    });
+
+    it('should return an error for a response that is not ok', () => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: false
+        })
+      });
+      expect(removeItem(mockId, 'project')).rejects.toEqual(
+        Error('Error: There was a problem deleting project id 123.'));
+    });
+  });
+
+  describe('remove Palette', () => {
+    let mockId = 500;
+    let mockResponse = `Palette with id 500 has been removed successfully`;
+    const mockOptions = {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      };
+
+    beforeEach(() => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          json: () => {
+            return Promise.resolve(mockResponse);
+          }
+        });
+      });
+    });
+
+    it('should be passed the correct URL', () => {
+      removeItem(mockId, 'palette');
+      expect(window.fetch).toHaveBeenCalledWith(
+        'https://palette-picks.herokuapp.com/api/v1/palettes/500',
+          mockOptions);
+    });
+
+    it('should return an object with the project id', () => {
+      expect(removeItem(mockId, 'palette')).resolves.toEqual(mockResponse);
+    });
+
+    it('should return an error for a response that is not ok', () => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: false
+        })
+      });
+      expect(removeItem(mockId, 'palette')).rejects.toEqual(
+        Error('Error: There was a problem deleting palette id 500.'));
+    });
+  });
+
 });

--- a/src/apiCalls.test.js
+++ b/src/apiCalls.test.js
@@ -1,4 +1,4 @@
-import { getProjects, addProject, getPalettes, getSpecificPalette, addPalette, removeItem }
+import { getProjects, addProject, getPalettes, getSpecificPalette, addPalette, removeItem, updateItem }
   from './apiCalls';
 
 describe('getProjects', () => {
@@ -375,6 +375,99 @@ describe('removeItem', () => {
       });
       expect(removeItem(mockId, 'palette')).rejects.toEqual(
         Error('Error: There was a problem deleting palette id 500.'));
+    });
+  });
+
+});
+
+describe('updateItem', () => {
+
+  describe('update Project', () => {
+    let mockId = 123;
+    let mockUpdated_Name: 'New and Improved Project Name';
+    let mockResponse = { id: 123 };
+    const mockOptions = {
+      method: 'PATCH',
+      body: JSON.stringify({name: mockUpdated_Name}),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    };
+
+    beforeEach(() => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          json: () => {
+            return Promise.resolve(mockResponse);
+          }
+        });
+      });
+    });
+
+    it('should be passed the correct URL', () => {
+      updateItem(mockId, 'project', mockUpdated_Name);
+      expect(window.fetch).toHaveBeenCalledWith(
+        'https://palette-picks.herokuapp.com/api/v1/projects/123',
+          mockOptions);
+    });
+
+    it('should return an object with the project id', () => {
+      expect(updateItem(mockId, 'project', mockUpdated_Name)).resolves.toEqual(mockResponse);
+    });
+
+    it('should return an error for a response that is not ok', () => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: false
+        })
+      });
+      expect(updateItem(mockId, 'project', mockUpdated_Name)).rejects.toEqual(
+        Error('Error: There was a problem updating project id 123.'));
+    });
+  });
+
+  describe('update Palette', () => {
+    let mockId = 500;
+    let mockUpdated_Name: 'New and Improved Palette Name';
+    let mockResponse = { id: 500 };
+    const mockOptions = {
+      method: 'PATCH',
+      body: JSON.stringify({name: mockUpdated_Name}),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    };
+    beforeEach(() => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          json: () => {
+            return Promise.resolve(mockResponse);
+          }
+        });
+      });
+    });
+
+    it('should be passed the correct URL', () => {
+      updateItem(mockId, 'palette', mockUpdated_Name);
+      expect(window.fetch).toHaveBeenCalledWith(
+        'https://palette-picks.herokuapp.com/api/v1/palettes/500',
+          mockOptions);
+    });
+
+    it('should return an object with the project id', () => {
+      expect(updateItem(mockId, 'palette', mockUpdated_Name)).resolves.toEqual(mockResponse);
+    });
+
+    it('should return an error for a response that is not ok', () => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: false
+        })
+      });
+      expect(updateItem(mockId, 'palette', mockUpdated_Name)).rejects.toEqual(
+        Error('Error: There was a problem updating palette id 500.'));
     });
   });
 


### PR DESCRIPTION
### What's this PR do?  
- [x] Add api calls for 
    - [x] Delete a project
    - [x] Delete a palette
    - [x] Update/Patch a project name
    - [x] Update/Patch a palette name

- [x] Add passing tests for the 4 api calls above

### How should this be manually tested?  
- Pull down branch and run `npm test src/apiCalls.test.js`

### Any background context you want to provide?
- Delete apiCall is dynamic for either project or palette deletion
    - It needs 2 arguments 
      1) idToBeDeleted
      2) itemToBeDeleted ('project' or 'palette')
- Patch apiCall is dynamic for either project or palette name update
    - It needs 3 arguments 
      1) idToBeDeleted
      2) itemToBeDeleted ('project' or 'palette')
      3) newNameToUpdateItTo

### What are the relevant tickets?
This will close issue #45 
